### PR TITLE
change to use fluent-plugin-cloudfront-log

### DIFF
--- a/lib/fluent/plugin/filter_cf_query.rb
+++ b/lib/fluent/plugin/filter_cf_query.rb
@@ -1,7 +1,7 @@
 class Fluent::CfQueryFilter < Fluent::Filter
   Fluent::Plugin.register_filter('cf_query', self)
   def filter(tag, time, record)
-    return nil unless record['day'].start_with?('2')
-    Hash[URI.decode_www_form(record['cs_uri_query'])]
+    return nil unless record['date'].start_with?('2')
+    Hash[URI.decode_www_form(record['cs-uri-query'])]
   end
 end


### PR DESCRIPTION
change key to use fluent-plugin-cloudfront-log
https://github.com/kubihie/fluent-plugin-cloudfront-log

```
## File input
<source>
  @type       cloudfront_log
  log_bucket  cloudfront-logs
  log_prefix  production
  region      us-east-1
  interval    300
  aws_key_id  xxxxxx
  aws_sec_key xxxxxx
  tag         reverb.cloudfront
  verbose     true
</source>

## custom filter
<filter reverb.cloudfront>
  @type cf_query
</filter>
```
